### PR TITLE
Fix link to license file in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ with some additional goals:
 
 Some Code (c) [Jonas Persson](https://github.com/jop-io) and
 [Tobbe Lundberg](https://github.com/Tobbe) which they have gracefully released
-under a MIT license. See [LICENCE](/swantzter/kontonummer/blob/main/LICENSE)
+under a MIT license. See [LICENCE](LICENSE)
 
 This implementation is written in TypeScript but the following specification
 should be applicable to other languages as well. But some language specific


### PR DESCRIPTION
old link: https://github.com/swantzter/kontonummer/blob/main/swantzter/kontonummer/blob/main/LICENSE
new link: https://github.com/swantzter/kontonummer/blob/main/LICENSE