### PR TITLE
fix: Add "type": "module" to package.json for ESM compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "kontonummer",
+  "type": "module",
   "version": "4.0.1",
   "description": "A validator for swedish banking numbers",
   "author": "Svante Bengtson <svante@swantzter.se> (https://swantzter.se)",


### PR DESCRIPTION
This change adds the "type": "module" field to the package.json file to ensure the package is correctly recognized as an ES Module. This resolves issues with bundlers and compilers, such as Vite, that require explicit module type declarations to handle ESM syntax properly.

Without this field, certain environments may misinterpret ESM syntax, leading to errors during development and build processes. This update improves compatibility and developer experience.